### PR TITLE
layer.conf: Add dunfell compatibility

### DIFF
--- a/meta-microblaze/conf/layer.conf
+++ b/meta-microblaze/conf/layer.conf
@@ -11,4 +11,4 @@ BBFILE_PRIORITY_xilinx-microblaze = "5"
 
 LAYERDEPENDS_xilinx-microblaze = "core"
 
-LAYERSERIES_COMPAT_xilinx-microblaze = "gatesgarth"
+LAYERSERIES_COMPAT_xilinx-microblaze = "dunfell gatesgarth"

--- a/meta-xilinx-bsp/conf/layer.conf
+++ b/meta-xilinx-bsp/conf/layer.conf
@@ -18,7 +18,7 @@ chromium-browser-layer:${LAYERDIR}/dynamic-layers/chromium-browser-layer/recipes
 
 LAYERDEPENDS_xilinx = "core"
 
-LAYERSERIES_COMPAT_xilinx = "gatesgarth"
+LAYERSERIES_COMPAT_xilinx = "dunfell gatesgarth"
 
 SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += " \
   *->zocl \

--- a/meta-xilinx-contrib/conf/layer.conf
+++ b/meta-xilinx-contrib/conf/layer.conf
@@ -12,6 +12,6 @@ BBFILE_PRIORITY_xilinx-contrib = "5"
 LAYERDEPENDS_xilinx-contrib = "core"
 LAYERDEPENDS_xilinx-contrib = "xilinx"
 
-LAYERSERIES_COMPAT_xilinx-contrib = "gatesgarth"
+LAYERSERIES_COMPAT_xilinx-contrib = "dunfell gatesgarth"
 
 XILINX_RELEASE_VERSION = "v2021.1"

--- a/meta-xilinx-pynq/conf/layer.conf
+++ b/meta-xilinx-pynq/conf/layer.conf
@@ -11,5 +11,5 @@ BBFILE_PRIORITY_xilinx-pynq = "5"
 
 LAYERDEPENDS_xilinx-pynq = "core xilinx"
 
-LAYERSERIES_COMPAT_xilinx-pynq = "gatesgarth"
+LAYERSERIES_COMPAT_xilinx-pynq = "dunfell gatesgarth"
 

--- a/meta-xilinx-standalone-experimental/conf/layer.conf
+++ b/meta-xilinx-standalone-experimental/conf/layer.conf
@@ -18,4 +18,4 @@ LAYERDEPENDS_xilinx-standalone-exp = "core \
 	xilinx-microblaze \
 	"
 
-LAYERSERIES_COMPAT_xilinx-standalone-exp = "gatesgarth"
+LAYERSERIES_COMPAT_xilinx-standalone-exp = "dunfell gatesgarth"

--- a/meta-xilinx-standalone/conf/layer.conf
+++ b/meta-xilinx-standalone/conf/layer.conf
@@ -15,5 +15,5 @@ BBFILE_PRIORITY_xilinx-standalone = "7"
 LAYERDEPENDS_xilinx-standalone = "core xilinx"
 LAYERRECOMMENDS_xilinx-standalone = "xilinx-microblaze"
 
-LAYERSERIES_COMPAT_xilinx-standalone = "gatesgarth"
+LAYERSERIES_COMPAT_xilinx-standalone = "dunfell gatesgarth"
 XILINX_RELEASE_VERSION = "v2021.1"


### PR DESCRIPTION
Adds dunfell compatibility to all layer.conf files.

Signed-off-by: ekalemen <eugeny_kalemenev@mentor.com>